### PR TITLE
Return copy of data to avoid accidental modification of dataset

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -61,7 +61,7 @@ class YinYangDataset(Dataset):
         return np.sqrt((x - 0.5 * self.r_big)**2 + (y - self.r_big)**2)
 
     def __getitem__(self, index):
-        sample = (self.__vals[index], self.__cs[index])
+        sample = (self.__vals[index].copy(), self.__cs[index])
         if self.transform:
             sample = self.transform(sample)
         return sample


### PR DESCRIPTION
This PR makes sure that samples obtained via `__getitem__` do not contain references to the original data by copying the data array. This avoids potential issues when applying transformations. Previously these may have modified the underlying dataset.