### PR TITLE
Remove unused `to_spike_train` transform

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -68,18 +68,3 @@ class YinYangDataset(Dataset):
 
     def __len__(self):
         return len(self.__cs)
-
-# Example transform to generate T long discrete spike train
-class to_spike_train(object):
-    def __init__(self, T):
-        self.T = T
-        self.no_classes = 3
-
-    def __call__(self, sample):
-        no_neurons = sample[0].shape[0]
-        spike_train = np.zeros((self.T, no_neurons))
-        spike_train[[int(np.round(x * self.T)) for x in sample[0]], np.arange(0,no_neurons)] = 1.
-
-        out_s =  np.zeros((self.T, self.no_classes))
-        out_s[:,sample[1]] = 1
-        return (spike_train, out_s)


### PR DESCRIPTION
This PR removes an example transform (introduced by #2) which is not used anywhere in the dataset class and should hence rather be defined in the project that is using it or in script a separate examples/ directory demonstrating how this can be used.